### PR TITLE
Port checking and better reconnection logics

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ When used together, the plugin ensures that the Nicotine+ client always uses the
 
 1. After the plugin is added, you should see it listed in the **Plugins** section of the settings.
 2. Enable the plugin by checking the box next to its name.
-3. The plugin will now run automatically in the background and check for updated port numbers every 24 hours.
+3. The plugin will now run automatically in the background and check for updated port numbers every hour. You can change the schedule by manually editing the first attribute of `threading.Timer()` under \_\_init\_\_.py.
 
 ## How It Works
 

--- a/gluetun-auto-port-set/__init__.py
+++ b/gluetun-auto-port-set/__init__.py
@@ -23,7 +23,7 @@ class Plugin(BasePlugin):
         self.update_port()
 
         # Schedule the next run in 24 hours (86400 seconds)
-        threading.Timer(86400, self.run_update_port).start()
+        threading.Timer(3600, self.run_update_port).start()
 
     def update_port(self):
         # Get port from gluetun

--- a/gluetun-auto-port-set/__init__.py
+++ b/gluetun-auto-port-set/__init__.py
@@ -10,7 +10,7 @@ class Plugin(BasePlugin):
 
         G_HOST = os.environ.get('GLUETUN_HOST',"localhost")
         G_PORT = os.environ.get('GLUETUN_PORT',8000)
-        self.glutun_api = VpnControlServerApi(G_HOST, G_PORT, self.log)
+        self.gluetun_api = VpnControlServerApi(G_HOST, G_PORT, self.log)
         # Set up the task to run daily
         self.setup_daily_task()
 
@@ -26,21 +26,30 @@ class Plugin(BasePlugin):
         threading.Timer(86400, self.run_update_port).start()
 
     def update_port(self):
+        # Get port from gluetun
         try:
-            vpn_port = self.glutun_api.forwarded_port
+            vpn_port = self.gluetun_api.forwarded_port
         except Exception as e:
             self.log(f"Error fetching VPN port: {str(e)}")
             return
-        try:
-            self.config.sections["server"]["portrange"] = (vpn_port, vpn_port)
-            self.core.reconnect()
-        except Exception as e:
-            self.log("Could not access settings or configuration. Required Nicotine version is 3.3.7+ for method reconnect")
-            self.log(e)
-            return
         
-        new_port_range = self.config.sections["server"]["portrange"]
-        self.log(f"New port range is: {new_port_range}, success")
+        # Get the current port range in Nicotine
+        old_port_range = self.config.sections["server"]["portrange"]
+
+        # If the port range has changed, set the new one
+        new_port_range = (vpn_port, vpn_port)
+        if old_port_range != new_port_range:
+            self.log("The forwarded port has changed, setting new port...")
+            self.log(f"Current port range is: {old_port_range}")
+            try:
+                self.config.sections["server"]["portrange"] = new_port_range
+                self.core.reconnect()
+            except Exception as e:
+                self.log("Could not access settings or configuration. Required Nicotine version is 3.3.7+ for method reconnect")
+                self.log(e)
+                return
+        
+            self.log(f"New port range is: {new_port_range}, success")
     
     def __del__(self):
         """Stop any pending scheduled tasks when the plugin is destroyed."""

--- a/gluetun-auto-port-set/__init__.py
+++ b/gluetun-auto-port-set/__init__.py
@@ -11,18 +11,20 @@ class Plugin(BasePlugin):
         G_HOST = os.environ.get('GLUETUN_HOST',"localhost")
         G_PORT = os.environ.get('GLUETUN_PORT',8000)
         self.gluetun_api = VpnControlServerApi(G_HOST, G_PORT, self.log)
-        # Set up the task to run daily
-        self.setup_daily_task()
+        # Set up the task to run on a schedule
+        self.setup_scheduled_task()
 
-    def setup_daily_task(self):
-        # Calculate the time until the next "daily" execution (24 hours from now)
+    def setup_scheduled_task(self):
+        # Calculate the time until the next execution
         self.run_update_port()
     
     def run_update_port(self):
         """This method will be called to perform the task and then reschedule itself."""
         self.update_port()
+        # Check that the port is open
+        threading.Timer(300, self.check_port_open).start()
 
-        # Schedule the next run in 24 hours (86400 seconds)
+        # Schedule the next run in X seconds
         threading.Timer(3600, self.run_update_port).start()
 
     def update_port(self):
@@ -50,6 +52,11 @@ class Plugin(BasePlugin):
                 return
         
             self.log(f"New port range is: {new_port_range}, success")
+
+    def check_port_open(self):
+        port = self.config.sections["server"]["portrange"][0]
+        if self.gluetun_api.is_port_closed(port):
+            pass
     
     def __del__(self):
         """Stop any pending scheduled tasks when the plugin is destroyed."""

--- a/gluetun-auto-port-set/vpnControl.py
+++ b/gluetun-auto-port-set/vpnControl.py
@@ -78,7 +78,6 @@ class VpnControlServerApi(object):
                 
                 # Check if the port status is open
                 if f"{port}/tcp open".encode() in response_body:
-                    self._log(f"Port {port} is open")
                     result = False
                 elif f"{port}/tcp closed".encode() in response_body:
                     self._log(f"Port {port} is closed")

--- a/gluetun-auto-port-set/vpnControl.py
+++ b/gluetun-auto-port-set/vpnControl.py
@@ -64,3 +64,30 @@ class VpnControlServerApi(object):
         else:
             self._log("Missing port data")
             raise Exception("VpnServerInvalidPortException")
+        
+    def is_port_closed(self, port):
+        """Use the Slsknet port test to check that the port is open"""
+        try:
+            # Form the URL to check the port
+            url = f"https://www.slsknet.org/porttest.php?port={port}"
+            
+            # Open the URL and read the response
+            with urllib.request.urlopen(url, timeout=5) as response:
+                # Read the response and decode it to a string
+                response_body = response.read().lower()
+                
+                # Check if the port status is open
+                if f"{port}/tcp open".encode() in response_body:
+                    self._log(f"Port {port} is open")
+                    result = False
+                elif f"{port}/tcp closed".encode() in response_body:
+                    self._log(f"Port {port} is closed")
+                    result = True
+                else:
+                    self._log(f"Unknown response from port checker: {response_body}")
+
+                return result
+
+        except urllib.error.URLError as e:
+            self._log(f"Error: {e}")
+            return 1


### PR DESCRIPTION
# New features
- **Port checker**: check that the port is open by querying the slsknet port test
# Fixes
- **No forced reconnection**: the plugin does not force a reconnection now if the listening port doesn't need to be changed. This allows for more frequent runs (now bumped to one every hour instead of one per day) without causing disconnections.
# Documentation
- **Schedule**: specified that the schedule on which the plugin checks for the Gluetun port can be amended manually if one prefers more/less frequent updates